### PR TITLE
fix content range error

### DIFF
--- a/backend/routes/dash.go
+++ b/backend/routes/dash.go
@@ -74,7 +74,7 @@ func (r *Routes) GetStreamFile(w http.ResponseWriter, req *http.Request) {
 	} else {
 		// Accept ranges
 		w.Header().Set("Accept-Ranges", "bytes")
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Length, size))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Start+ranges[0].Length-1, size))
 
 		// Set the status code
 		w.WriteHeader(http.StatusPartialContent)

--- a/backend/routes/internal.go
+++ b/backend/routes/internal.go
@@ -118,7 +118,7 @@ func (r *Routes) ReadObject(w http.ResponseWriter, req *http.Request) {
 
 		// Accept ranges
 		w.Header().Set("Accept-Ranges", "bytes")
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Length, size))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Start+ranges[0].Length-1, size))
 		w.Header().Set("Content-Length", fmt.Sprint(ranges[0].Length))
 
 		// Set the status code


### PR DESCRIPTION
Fixes an incorrect `Content-Range` header in partial responses (https://github.com/golang/go/blob/master/src/net/http/fs.go#L885)

This fixes different video qualities not playing properly.