### PR TITLE
Add additional route handler middleware

### DIFF
--- a/backend/routes/dash.go
+++ b/backend/routes/dash.go
@@ -6,87 +6,70 @@ import (
 	"net/http"
 	"webserver/models"
 
+	"github.com/friendsofgo/errors"
 	"github.com/gotd/contrib/http_range"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 )
 
-func (r *Routes) GetStreamFile(w http.ResponseWriter, req *http.Request) {
+func (r *Routes) GetStreamFile(u *models.User, req *http.Request) (int, io.ReadCloser, http.Header, error) {
 	vars := vars(req)
 
 	if !r.ObjectStore.HasObject(req.Context(), vars.CID, vars.Filename) {
-		http.Error(w, "Not Found", http.StatusNotFound)
-		return
+		return http.StatusNotFound, nil, nil, nil
 	}
 
 	// Get the object from the minio server
 	objReader, size, err := r.ObjectStore.GetObject(req.Context(), vars.CID, vars.Filename)
 
 	if err != nil {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
+		return http.StatusInternalServerError, nil, nil, errors.Wrap(err, "failed to get object")
 	}
-
-	defer objReader.Close()
 
 	if vars.Filename == "dash.mpd" {
 		// Get the clip to increment views by cid
 		clip, err := r.Clips.Find(req.Context(), vars.CID)
 
 		if err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+			return http.StatusInternalServerError, nil, nil, errors.Wrap(err, "failed to find clip")
 		}
 
 		clip.Views++
 
 		if err := r.Clips.Update(req.Context(), clip, boil.Whitelist(models.ClipColumns.Views)); err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+			return http.StatusInternalServerError, nil, nil, errors.Wrap(err, "failed to update clip")
 		}
 	}
 
 	ranges, err := http_range.ParseRange(req.Header.Get("Range"), size)
 
 	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
-		return
+		return http.StatusBadRequest, StringToStream(errors.Wrap(err, "Invalid Range").Error()), nil, nil
 	}
 
 	if len(ranges) > 1 {
-		http.Error(w, "Requested Range Not Satisfiable", http.StatusRequestedRangeNotSatisfiable)
-		return
+		return http.StatusRequestedRangeNotSatisfiable, StringToStream("Multiple ranges not supported"), nil, nil
 	}
+
+	headers := make(http.Header)
 
 	if len(ranges) == 0 {
 		// Set the content length
-		w.Header().Set("Content-Length", fmt.Sprint(size))
+		headers.Set("Content-Length", fmt.Sprint(size))
 
-		// Copy the object to the response writer
-		_, err = io.Copy(w, objReader)
-		if err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		return
+		return http.StatusOK, objReader, headers, nil
 	} else {
 		// Accept ranges
-		w.Header().Set("Accept-Ranges", "bytes")
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Start+ranges[0].Length-1, size))
-		w.Header().Set("Content-Length", fmt.Sprint(ranges[0].Length))
+		headers.Set("Accept-Ranges", "bytes")
+		headers.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", ranges[0].Start, ranges[0].Start+ranges[0].Length-1, size))
+		headers.Set("Content-Length", fmt.Sprint(ranges[0].Length))
 
 		// Seek to the start of the range
 		_, err = objReader.Seek(ranges[0].Start, io.SeekStart)
 
 		if err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+			return http.StatusInternalServerError, nil, nil, errors.Wrap(err, "failed to seek to start of range")
 		}
 
-		// Set the status code
-		w.WriteHeader(http.StatusPartialContent)
-
-		io.CopyN(w, objReader, ranges[0].Length)
-		// TODO: Properly handle errors here and ignore if the error is due to the client disconnecting prematurely
+		return http.StatusPartialContent, NewLimitedReadCloser(objReader, ranges[0].Length), headers, nil
 	}
 }

--- a/backend/routes/middleware.go
+++ b/backend/routes/middleware.go
@@ -98,6 +98,11 @@ func (r *Routes) FullHandler(handler func(u *models.User, w http.ResponseWriter,
 		resp.WriteHeader(code)
 
 		if code == http.StatusInternalServerError {
+			// If for some reason body isn't nil and we're returning an internal server error, close it
+			if body != nil {
+				body.Close()
+			}
+
 			body = io.NopCloser(bytes.NewReader([]byte("Default Error Page")))
 		}
 

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -78,29 +78,29 @@ func New(cfg *config.Config, g *services.Group, store sessions.Store) (*Routes, 
 	internalEndpoint("/progress/{cid}", r.SetProgress, http.MethodPost)
 
 	// AUTH ENDPOINTS
-	endpoint("/auth/login", r.Login, http.MethodPost)
-	endpoint("/auth/register", r.Register, http.MethodPost)
-	endpoint("/auth/logout", r.Logout, http.MethodPost)
+	endpoint("/auth/login", r.ResponseHandler(r.Login), http.MethodPost)
+	endpoint("/auth/register", r.ResponseHandler(r.Register), http.MethodPost)
+	endpoint("/auth/logout", r.ResponseHandler(r.Logout), http.MethodPost)
 
 	// USER ENDPOINTS
-	endpoint("/users/search", r.Auth(r.SearchUsers), http.MethodGet)
-	endpoint("/users/me", r.Auth(r.GetCurrentUser), http.MethodGet)
-	endpoint("/users", r.Auth(r.GetUsers), http.MethodGet)
-	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}/clips", r.Auth(r.GetUsersClips), http.MethodGet)
-	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}", r.Auth(r.GetUser), http.MethodGet)
-	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}", r.Auth(r.UpdateUser), http.MethodPatch)
+	endpoint("/users/search", r.Handler(r.SearchUsers), http.MethodGet)
+	endpoint("/users/me", r.Handler(r.GetCurrentUser), http.MethodGet)
+	endpoint("/users", r.Handler(r.GetUsers), http.MethodGet)
+	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}/clips", r.Handler(r.GetUsersClips), http.MethodGet)
+	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}", r.Handler(r.GetUser), http.MethodGet)
+	endpoint("/users/{uid:[a-zA-Z0-9-]{4,}}", r.Handler(r.UpdateUser), http.MethodPatch)
 
 	// CLIP ENDPOINTS
-	endpoint("/clips", r.Auth(r.UploadClip), http.MethodPost)
-	endpoint("/clips", r.Auth(r.GetClips), http.MethodGet)
-	endpoint("/clips/search", r.Auth(r.SearchClips), http.MethodGet)
-	endpoint("/clips/progress", r.Auth(r.GetProgress), http.MethodGet)
-	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Auth(r.GetClip), http.MethodGet)
-	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Auth(r.UpdateClip), http.MethodPatch)
-	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Auth(r.DeleteClip), http.MethodDelete)
+	endpoint("/clips", r.Handler(r.UploadClip), http.MethodPost)
+	endpoint("/clips", r.Handler(r.GetClips), http.MethodGet)
+	endpoint("/clips/search", r.Handler(r.SearchClips), http.MethodGet)
+	endpoint("/clips/progress", r.Handler(r.GetProgress), http.MethodGet)
+	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Handler(r.GetClip), http.MethodGet)
+	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Handler(r.UpdateClip), http.MethodPatch)
+	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}", r.Handler(r.DeleteClip), http.MethodDelete)
 
 	// MPEG-DASH ENDPOINTS
-	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}/{filename}", r.GetStreamFile, http.MethodGet)
+	endpoint("/clips/{cid:[a-zA-Z0-9-]{4,}}/{filename}", r.StreamHandler(r.GetStreamFile), http.MethodGet)
 
 	if cfg.CORS.Enabled {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{


### PR DESCRIPTION
This PR unblocks https://github.com/clipable/clipable/pull/70 from being able to wrap errors properly in all routes. 

As well, it creates 3 different route `http.Handler` wrappers so all of our routes pass through the same middleware. Instead of having `auth.go` and `dash.go` manually writing responses.