### PR TITLE
Vertical video support

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -18,10 +18,11 @@ type Config struct {
 	MaxUploadSizeBytes int64  `ignored:"true"` // This is set by the parser to the byte value of MaxUploadSize
 
 	FFmpeg struct {
-		Concurrency int    `default:"1"`
-		Threads     int    `default:"0"`
-		Preset      string `default:"medium"` // https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=preset%20and%20tune-,Preset,-A%20preset%20is
-		Tune        string `default:"film"`   // https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=x264%20%2D%2Dfullhelp.-,Tune,-You%20can%20optionally
+		Concurrency    int      `default:"1"`
+		Threads        int      `default:"0"`
+		Preset         string   `default:"medium"` // https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=preset%20and%20tune-,Preset,-A%20preset%20is
+		Tune           string   `default:"film"`   // https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=x264%20%2D%2Dfullhelp.-,Tune,-You%20can%20optionally
+		QualityPresets []string `split_words:"true" default:"640x360-30@1,854x480-30@2.5,1280x720-30@5,1920x1080-30@8,1920x1080-60@12,2560x1440-30@16,2560x1440-60@24,3840x2160-30@45,3840x2160-60@68,7680x4320-30@160,7680x4320-60@240"`
 	}
 
 	CORS struct {

--- a/backend/routes/middleware.go
+++ b/backend/routes/middleware.go
@@ -207,22 +207,6 @@ func (r *Routes) ParseVars(next http.Handler) http.Handler {
 	})
 }
 
-func (r *Routes) SDCompliance(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate")
-		w.Header().Set("Pragma", "no-cache")
-		w.Header().Set("Expires", "-1")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Add("X-Frame-Options", "DENY")
-		w.Header().Add("frame-ancestors", "none")
-		w.Header().Add("frame-src", "none")
-		w.Header().Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-		w.Header().Add("Content-Security-Policy", "default-src 'none'; font-src 'none'; img-src 'self'; object-src 'none'; script-src 'self'")
-		w.Header().Add("X-XSS-Protection", "0")
-		next.ServeHTTP(w, req)
-	})
-}
-
 func getPaginationMods(req *http.Request, paginationColumn, table, idColumn string) []qm.QueryMod {
 	qms := make([]qm.QueryMod, 0)
 
@@ -347,7 +331,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			"method":  r.Method,
 			"written": humanize.Bytes(lw.written),
 			"read":    humanize.Bytes(uint64(r.ContentLength)),
-			"took":    latency,
+			"took":    latency.Round(time.Millisecond),
 		}).Info(r.URL.Path)
 	})
 }

--- a/backend/services/transcoder/resolution.go
+++ b/backend/services/transcoder/resolution.go
@@ -2,6 +2,7 @@ package transcoder
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -28,35 +29,18 @@ type FormatInfo struct {
 	Duration string `json:"duration"`
 }
 
-type StreamInfo struct {
-	Width      int    `json:"width"`
-	Height     int    `json:"height"`
-	Index      int    `json:"index"`
-	CodecType  string `json:"codec_type"`
-	RFrameRate string `json:"r_frame_rate"`
-	Duration   string `json:"duration"`
+type TagInfo struct {
+	Rotate string `json:"rotate"`
 }
 
-// https://support.google.com/youtube/answer/1722171?hl=en#zippy=%2Cbitrate
-var QualityPresets = []Quality{
-	// 360p
-	{Width: 640, Height: 360, Bitrate: 1, Framerate: 30},
-	// 480p
-	{Width: 854, Height: 480, Bitrate: 2.5, Framerate: 30},
-	// 720p
-	{Width: 1280, Height: 720, Bitrate: 5, Framerate: 30},
-	// 1080p
-	{Width: 1920, Height: 1080, Bitrate: 8, Framerate: 30},
-	{Width: 1920, Height: 1080, Bitrate: 12, Framerate: 60},
-	// 1440p
-	{Width: 2560, Height: 1440, Bitrate: 16, Framerate: 30},
-	{Width: 2560, Height: 1440, Bitrate: 24, Framerate: 60},
-	// 2160p
-	{Width: 3840, Height: 2160, Bitrate: 45, Framerate: 30},
-	{Width: 3840, Height: 2160, Bitrate: 68, Framerate: 60},
-	// 4320p
-	{Width: 7680, Height: 4320, Bitrate: 160, Framerate: 30},
-	{Width: 7680, Height: 4320, Bitrate: 240, Framerate: 60},
+type StreamInfo struct {
+	Width      int     `json:"width"`
+	Height     int     `json:"height"`
+	Index      int     `json:"index"`
+	CodecType  string  `json:"codec_type"`
+	RFrameRate string  `json:"r_frame_rate"`
+	Duration   string  `json:"duration"`
+	Tags       TagInfo `json:"tags"`
 }
 
 func bitString(bitrate float32) string {
@@ -64,7 +48,7 @@ func bitString(bitrate float32) string {
 }
 
 func GetVideoStats(file string) (width int, height int, fps int, duration time.Duration, audioStreams int, err error) {
-	cmd := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration:stream=width,height,r_frame_rate,index,codec_type,duration", "-sexagesimal", "-of", "json", file)
+	cmd := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration:stream=width,height,r_frame_rate,index,codec_type,duration:stream_tags=rotate", "-sexagesimal", "-of", "json", file)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, 0, 0, 0, 0, err
@@ -98,6 +82,11 @@ func GetVideoStats(file string) (width int, height int, fps int, duration time.D
 		return 0, 0, 0, 0, 0, err
 	}
 
+	// If the video is rotated 90 or 270 degrees swap the width and height
+	if videoStream.Tags.Rotate == "90" || videoStream.Tags.Rotate == "270" {
+		videoStream.Width, videoStream.Height = videoStream.Height, videoStream.Width
+	}
+
 	return videoStream.Width, videoStream.Height, fps, dur, audioStreams, nil
 }
 
@@ -129,31 +118,41 @@ func ParseSexagesimal(duration string) (time.Duration, error) {
 	return time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds*float64(time.Second)), nil
 }
 
-func GetPresets(width int, height int, fps int, audioStreams int) []string {
+func (t *transcoder) GetPresets(width int, height int, fps int, audioStreams int) []string {
 	if fps < 30 {
 		fps = 30
 	}
 
+	verticle := height > width
+	aspectRatio := "16:9"
+
+	if verticle {
+		aspectRatio = "9:16"
+		width, height = height, width
+	}
+
 	var presets []Quality
-	for _, preset := range QualityPresets {
+	for _, preset := range t.qualityPresets {
 		if preset.Width <= width && preset.Height <= height && preset.Framerate <= fps {
+			if verticle {
+				preset.Width, preset.Height = preset.Height, preset.Width
+			}
 			presets = append(presets, preset)
 		}
 	}
 
-	// TODO: What happens when someone uploads vertical video?
 	if len(presets) == 0 {
-		presets = []Quality{QualityPresets[0]} // If no quality was select use the lowest one
+		presets = []Quality{t.qualityPresets[0]} // If no quality was select use the lowest one
 	}
 
-	ffmpegArgs := []string{}
+	ffmpegArgs := []string{"-aspect", aspectRatio}
 
 	for i, preset := range presets {
 		ffmpegArgs = append(ffmpegArgs,
 			"-map",
 			"v:0",
-			"-s:"+strconv.Itoa(i),
-			strconv.Itoa(preset.Width)+"x"+strconv.Itoa(preset.Height),
+			"-vf:"+strconv.Itoa(i),
+			fmt.Sprintf("scale=w=%d:h=%d:force_original_aspect_ratio=1,pad=%d:%d:(ow-iw)/2:(oh-ih)/2", preset.Width, preset.Height, preset.Width, preset.Height),
 			"-b:v:"+strconv.Itoa(i),
 			bitString(preset.Bitrate),
 			"-maxrate:"+strconv.Itoa(i),

--- a/backend/services/transcoder/resolution.go
+++ b/backend/services/transcoder/resolution.go
@@ -123,10 +123,10 @@ func (t *transcoder) GetPresets(width int, height int, fps int, audioStreams int
 		fps = 30
 	}
 
-	verticle := height > width
+	vertical := height > width
 	aspectRatio := "16:9"
 
-	if verticle {
+	if vertical {
 		aspectRatio = "9:16"
 		width, height = height, width
 	}
@@ -134,7 +134,7 @@ func (t *transcoder) GetPresets(width int, height int, fps int, audioStreams int
 	var presets []Quality
 	for _, preset := range t.qualityPresets {
 		if preset.Width <= width && preset.Height <= height && preset.Framerate <= fps {
-			if verticle {
+			if vertical {
 				preset.Width, preset.Height = preset.Height, preset.Width
 			}
 			presets = append(presets, preset)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,15 +35,16 @@ services:
       exit 0;
       "
 
-  clippable:
+  clipable:
     image: ghcr.io/clipable/clipable:latest
+    # All of these environment variables are documented here: https://github.com/clipable/clipable/wiki/Environment-Variables
     environment:
       - DEBUG=true
       - LISTENADDR=:8080
-      - FFMPEG_CONCURRENCY=1 # How many concurrent ffmpeg processes to run
-      - FFMPEG_THREADS=0 # How many threads to use for a single ffmpeg process to use
-      - FFMPEG_PRESET=medium # How much time to spend compressing https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=preset%20and%20tune-,Preset,-A%20preset%20is
-      - FFMPEG_TUNE=film # https://trac.ffmpeg.org/wiki/Encode/H.264#:~:text=x264%20%2D%2Dfullhelp.-,Tune,-You%20can%20optionally
+      - FFMPEG_CONCURRENCY=1 
+      - FFMPEG_THREADS=0
+      - FFMPEG_PRESET=medium
+      - FFMPEG_TUNE=film
       - DB_HOST=postgres
       - DB_PORT=5432
       - DB_USER=postgres


### PR DESCRIPTION
- Adds FFmpeg quality presets in environment variables
- Removes some dead code
- Rounds time logged via http handlers
- Adds logic to handle vertical video when encoding
- Fixes extracting duration timestamps from MKV files
- Adds black bars instead of stretching when video isn't 16:9 or 9:16

Documentation has already been added at: https://github.com/clipable/clipable/wiki/Environment-Variables#ffmpeg-configuration

Closes https://github.com/clipable/clipable/issues/12
Closes https://github.com/clipable/clipable/issues/100