### PR TITLE
swap to nginx proxy, fix timeout issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 
 FROM ghcr.io/jrottenberg/ffmpeg:5-alpine
 
-RUN apk add --update nodejs
+RUN apk add --update --no-cache nodejs nginx
 
 ENV NODE_ENV production
 
@@ -40,6 +40,7 @@ COPY --from=frontend-builder /home/node/app/.next/standalone ./
 COPY --from=frontend-builder /home/node/app/.next/static ./.next/static
 
 COPY backend/migrations /migrations
+COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY --from=backend-build /app/clipable /
 
-ENTRYPOINT /clipable & node server.js
+ENTRYPOINT /clipable & node server.js & nginx -g "daemon off;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     # All of these environment variables are documented here: https://github.com/clipable/clipable/wiki/Environment-Variables
     environment:
       - DEBUG=true
-      - LISTENADDR=:8080
+      - MAX_UPLOAD_SIZE=5GB
       - FFMPEG_CONCURRENCY=1 
       - FFMPEG_THREADS=0
       - FFMPEG_PRESET=medium
@@ -58,7 +58,7 @@ services:
       - S3_SECRET=myminiokeythatishouldchange123
       - S3_ADDRESS=minio:9000
     ports:
-      - 80:3000
+      - 80:80
     depends_on:
       postgres:
         condition: service_healthy

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,54 @@
+pid /run/nginx.pid;
+worker_processes auto;
+worker_rlimit_nofile 65535;
+
+events {
+	multi_accept on;
+	worker_connections 65535;
+}
+
+http {
+	charset utf-8;
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	server_tokens off;
+	log_not_found off;
+	types_hash_max_size 2048;
+    # Let the backend handle max body size
+	client_max_body_size 0; 
+
+	# MIME
+	include mime.types;
+	default_type application/octet-stream;
+
+	# logging
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log warn;
+
+	server {
+		listen 80 default_server;
+		listen [::]:80 default_server;
+	
+		# reverse proxy
+		location / {
+			proxy_pass http://127.0.0.1:3000;
+		}
+
+        location /api {
+            # disable buffering
+            proxy_buffering off;
+            proxy_http_version 1.1;
+            proxy_request_buffering off;
+
+            # Let the backend handle timeouts
+            # These timeouts don't represent the entire read/send timeout
+            # but rather time between successful reads/writes
+            proxy_read_timeout 5m;
+            proxy_send_timeout 5m;
+
+			proxy_pass http://127.0.0.1:8080/api;
+		
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/clipable/clipable/issues/108
Closes https://github.com/clipable/clipable/issues/68

 - Somehow a bug has done unnoticed until now that if an upload takes longer than 10 seconds it will properly upload to the server, but a response will never be sent due to misconfigured timeouts, causing the frontend to display an error
 - Swaps us to nginx proxy instead of nextjs proxy. We've been meaning to do this due to the lack of controls in nextjs and it's questionable production ready status.
 
 Once this is merged, we'll release a minor version, so videos start uploading properly again.