### PR TITLE
pull gpu patches on container start

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -660,11 +660,7 @@ COPY --from=frontend-builder /home/node/app/.next/static ./.next/static
 
 COPY backend/migrations ./migrations
 COPY ./nginx.conf /etc/nginx/nginx.conf
+COPY gpu.entrypoint.sh .
 COPY --from=backend-build /app/clipable .
 
-RUN curl https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh > /usr/local/bin/patch.sh && \
-        curl https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh > docker-entrypoint.sh && \
-        chmod +x /usr/local/bin/patch.sh && \
-        chmod +x docker-entrypoint.sh
-
-ENTRYPOINT ./docker-entrypoint.sh && ./clipable & node ./server.js & nginx -g "daemon off;"
+ENTRYPOINT ./gpu.entrypoint.sh

--- a/gpu.entrypoint.sh
+++ b/gpu.entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+curl -Ss https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh > /usr/local/bin/patch.sh
+curl -Ss https://raw.githubusercontent.com/keylase/nvidia-patch/master/docker-entrypoint.sh > docker-entrypoint.sh
+
+chmod +x /usr/local/bin/patch.sh
+chmod +x docker-entrypoint.sh
+
+./docker-entrypoint.sh
+
+./clipable & node ./server.js & nginx -g "daemon off;"


### PR DESCRIPTION
Instead of re-triggering artifact generation every time a new patch for an nvidia driver comes out, we're just going to pull the gpu patching script on startup instead of baking it into the image itself.

this will have some consequences for offline installs, but until we get feedback that this is an issue we'll go with this method.