### PR TITLE
Process Supervisor, GPU version bump + fix, Blackbar Removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN pnpm build
 
 FROM node:alpine
 
-RUN apk add --update --no-cache nginx
+WORKDIR /clipable
+RUN apk add --update --no-cache nginx supervisor
 
 ENV NODE_ENV production
 
@@ -36,8 +37,9 @@ COPY --from=frontend-builder /home/node/app/.next/static ./.next/static
 COPY --from=mwader/static-ffmpeg:6.0 /ffmpeg /usr/local/bin/
 COPY --from=mwader/static-ffmpeg:6.0 /ffprobe /usr/local/bin/
 
-COPY backend/migrations /migrations
+COPY backend/migrations ./migrations
 COPY ./nginx.conf /etc/nginx/nginx.conf
-COPY --from=backend-build /app/clipable /
+COPY --from=backend-build /app/clipable ./
+COPY ./supervisord.conf ./supervisord.conf
 
-ENTRYPOINT /clipable & node server.js & nginx -g "daemon off;"
+ENTRYPOINT ["supervisord", "-c", "./supervisord.conf"]

--- a/backend/services/transcoder/resolution.go
+++ b/backend/services/transcoder/resolution.go
@@ -159,7 +159,7 @@ func (t *transcoder) GetPresets(width int, height int, fps int, audioStreams int
 			"-s:v:"+strconv.Itoa(i),
 			fmt.Sprintf("%dx%d", preset.Width, preset.Height),
 			"-vf:"+strconv.Itoa(i),
-			fmt.Sprintf("scale=w=%d:h=%d:force_original_aspect_ratio=1,pad=%d:%d:(ow-iw)/2:(oh-ih)/2", preset.Width, preset.Height, preset.Width, preset.Height),
+			fmt.Sprintf("scale=w=%d:h=%d:force_original_aspect_ratio=1", preset.Width, preset.Height),
 			"-b:v:"+strconv.Itoa(i),
 			bitString(preset.Bitrate),
 			"-maxrate:"+strconv.Itoa(i),

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -16,11 +16,11 @@ COPY frontend/ .
 RUN pnpm install -r --offline
 RUN pnpm build
 
-FROM ghcr.io/aperim/nvidia-cuda-ffmpeg:12.2.0-6.0-ubuntu22.04-0.3.5
+FROM ghcr.io/aperim/nvidia-cuda-ffmpeg:12.2.2-6.1.1-ubuntu22.04-0.3.6
 WORKDIR /clipable
 RUN apt update && apt install -y --no-install-recommends curl nginx && \
         curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
-        apt install -y nodejs && \
+        apt install -y nodejs supervisor && \
         npm install pnpm
 
 ENV NODE_ENV production
@@ -39,5 +39,6 @@ COPY backend/migrations ./migrations
 COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY gpu.entrypoint.sh .
 COPY --from=backend-build /app/clipable .
+COPY ./supervisord.conf /supervisord.conf
 
 ENTRYPOINT ./gpu.entrypoint.sh

--- a/gpu.docker-compose.yml
+++ b/gpu.docker-compose.yml
@@ -62,6 +62,8 @@ services:
       S3_SECRET: myminiokeythatishouldchange123
       S3_ADDRESS: minio:9000
       S3_SECURE: false
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: all
     ports:
       - 80:80
     depends_on:

--- a/gpu.entrypoint.sh
+++ b/gpu.entrypoint.sh
@@ -8,4 +8,4 @@ chmod +x docker-entrypoint.sh
 
 ./docker-entrypoint.sh
 
-./clipable & node ./server.js & nginx -g "daemon off;"
+supervisord -c /supervisord.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,7 +38,6 @@ http {
 		server 127.0.0.1:8080;
 	}
 
-
 	server {
 		listen 80 default_server;
 		listen [::]:80 default_server;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:clipable]
+command=/clipable/clipable
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nodejs]
+command=node server.js
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=nginx -g "daemon off;"
+autorestart=true


### PR DESCRIPTION
- Added `supervisord` to monitor backend, frontend, and nginx. This fixes an issue where if the backend failed to start due to postgres not being ready, the container wouldn't restart and just idle in a broken state. 
- Bumped NVIDIA/FFmpeg version in gpu dockerfile.
- Added missing GPU environment variables that were causing encoding shared libraries to not load properly when trying to encode a video with GPU. 
- Removed blackbar scaling when video aspect ratios don't align. This never really worked that well in the first place and looks very poor when processing vertical video content. We now just stretch to fit either 16:9 or 9:16. This may be revisited in the future if someone is motivated enough to handle all the resolution scale edge cases. 